### PR TITLE
fix(tailorctl): simplify completion script generation in tailorctl formula

### DIFF
--- a/Formula/tailorctl.rb
+++ b/Formula/tailorctl.rb
@@ -15,12 +15,7 @@ class Tailorctl < Formula
 
       def install
         bin.install "tailorctl"
-        bash_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "bash")
-        (bash_completion/"tailorctl").write bash_output
-        zsh_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "zsh")
-        (zsh_completion/"tailorctl").write zsh_output
-        fish_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "fish")
-        (fish_completion/"tailorctl.fish").write fish_output
+        generate_completions_from_executable(bin/"tailorctl", "completion")
       end
     end
     if Hardware::CPU.intel?
@@ -29,12 +24,7 @@ class Tailorctl < Formula
 
       def install
         bin.install "tailorctl"
-        bash_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "bash")
-        (bash_completion/"tailorctl").write bash_output
-        zsh_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "zsh")
-        (zsh_completion/"tailorctl").write zsh_output
-        fish_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "fish")
-        (fish_completion/"tailorctl.fish").write fish_output
+        generate_completions_from_executable(bin/"tailorctl", "completion")
       end
     end
   end
@@ -46,12 +36,7 @@ class Tailorctl < Formula
 
       def install
         bin.install "tailorctl"
-        bash_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "bash")
-        (bash_completion/"tailorctl").write bash_output
-        zsh_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "zsh")
-        (zsh_completion/"tailorctl").write zsh_output
-        fish_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "fish")
-        (fish_completion/"tailorctl.fish").write fish_output
+        generate_completions_from_executable(bin/"tailorctl", "completion")
       end
     end
     if Hardware::CPU.intel?
@@ -60,12 +45,7 @@ class Tailorctl < Formula
 
       def install
         bin.install "tailorctl"
-        bash_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "bash")
-        (bash_completion/"tailorctl").write bash_output
-        zsh_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "zsh")
-        (zsh_completion/"tailorctl").write zsh_output
-        fish_output = Utils.safe_popen_read(bin/"tailorctl", "completion", "fish")
-        (fish_completion/"tailorctl.fish").write fish_output
+        generate_completions_from_executable(bin/"tailorctl", "completion")
       end
     end
   end


### PR DESCRIPTION
This pull request includes changes to the `Formula/tailorctl.rb` file to simplify the generation of shell completions for the `tailorctl` command. The most important change is the replacement of multiple lines of code for generating shell completions with a single method call.

Simplification of shell completion generation:

* [`Formula/tailorctl.rb`](diffhunk://#diff-be069df32bc064464fa85df8aaa98eba2e0f92bee33589bbae94f2adc161758cL18-R18): Replaced individual commands for generating bash, zsh, and fish completions with a single `generate_completions_from_executable` method call. [[1]](diffhunk://#diff-be069df32bc064464fa85df8aaa98eba2e0f92bee33589bbae94f2adc161758cL18-R18) [[2]](diffhunk://#diff-be069df32bc064464fa85df8aaa98eba2e0f92bee33589bbae94f2adc161758cL32-R27) [[3]](diffhunk://#diff-be069df32bc064464fa85df8aaa98eba2e0f92bee33589bbae94f2adc161758cL49-R39) [[4]](diffhunk://#diff-be069df32bc064464fa85df8aaa98eba2e0f92bee33589bbae94f2adc161758cL63-R48)