### PR TITLE
chore: add catch-all CODEOWNERS entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tailor-platform/maintainers-homebrew-tap


### PR DESCRIPTION
Adds a catch-all CODEOWNERS rule so every path in this repo has an owner and
pull requests get a review request automatically.

`@tailor-platform/maintainers-homebrew-tap` is the team that already holds push access here.

GitHub applies the last matching rule, so narrower per-path rules can be added
below the catch-all later.

Draft — happy to switch to a narrower rule or a different team if this isn't the
right owner.
